### PR TITLE
Update Lucene WhitespaceAnalyzer package path

### DIFF
--- a/app/collection_doc.xconf
+++ b/app/collection_doc.xconf
@@ -7,7 +7,7 @@
     <!-- Lucene index is configured below -->
     <lucene>
       <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
-      <analyzer id="ws" class="org.apache.lucene.analysis.WhitespaceAnalyzer"/>
+      <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
       <text qname="tei:TEI"/>
     </lucene>
     <range>

--- a/app/collection_pub.xconf
+++ b/app/collection_pub.xconf
@@ -8,7 +8,7 @@
     
     <lucene>
       <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
-      <analyzer id="ws" class="org.apache.lucene.analysis.WhitespaceAnalyzer"/>
+      <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
       <text qname="tei:TEI"/>
     </lucene>
     <range>           


### PR DESCRIPTION
This pull request updates the Java package path for the Lucene WhitespaceAnalyzer. For more information, see:
- the eXist-db known issues when upgrading guide ([here](https://exist-db.org/exist/apps/doc/incompatibilities#v2.2))
- the relevant Apache/Lucene ticket LUCENE-2413 ([here](https://issues.apache.org/jira/browse/LUCENE-2413))