### PR TITLE
Drop deprecated webstats snippets

### DIFF
--- a/app/templates/page.html
+++ b/app/templates/page.html
@@ -120,26 +120,5 @@
                 <a href="#">informação legal</a>
             </div>
         </div>
-        <!-- Matomo -->
-        <script type="text/javascript">
-            var _paq = window._paq = window._paq || [];
-            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-            _paq.push(['trackPageView']);
-            _paq.push(['enableLinkTracking']);
-            (function() {
-            var u="https://webstats.cceh.uni-koeln.de/";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', '10']);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-            })();
-            calcImage();
-          </script>
-        <noscript>
-            <p>
-                <img src="//projects.cceh.uni-koeln.de/piwik/piwik.php?idsite=10" style="border:0;" alt=""/>
-            </p>
-        </noscript>
-        <!-- End Matomo Code -->
     </body>
 </html>


### PR DESCRIPTION
This pull request removes the deprecated CCeH webstats snippets from the `page.html` template. This does not mean the deployed application will be excluded from those services, but rather that the new deployment strategy at the CCeH moves the webstats-tracking out of the application code.